### PR TITLE
Fixed emty &tplWrapper output

### DIFF
--- a/core/components/pdotools/elements/snippets/snippet.pdoneighbors.php
+++ b/core/components/pdotools/elements/snippets/snippet.pdoneighbors.php
@@ -124,6 +124,12 @@ $rows = $pdoFetch->run();
 $prev = array_flip($prev);
 $next = array_flip($next);
 
+if (!count($rows)) {
+    // do not output empty &tplWrapper
+    $pdoFetch->addTime('Nothing was found');
+    return;
+}
+
 $output = array('prev' => array(), 'up' => array(), 'next' => array());
 foreach ($rows as $row) {
     if (empty($row['menutitle'])) {


### PR DESCRIPTION
Когда задавался параметр "where", с которым выводилось ноль результатов, выдавался пустой &tplWrapper из-за пустого массива из строки 133.